### PR TITLE
Add throttling to download network call and move all URLs to separate…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@ coverage:
           - "src"
        # advanced settings
         branches: 
-          - master
+          - *
         if_ci_failed: error #success, failure, error, ignore
         informational: false
         only_pulls: false

--- a/src/URLs.ts
+++ b/src/URLs.ts
@@ -1,0 +1,3 @@
+export const RCSB_FILES_URL = "https://files.rcsb.org/view/";
+export const NCBI_PUBCHEM_URL = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/";
+export const RCSB_MMTF_URL = "https://mmtf.rcsb.org/v1.0/full/";

--- a/src/autoload.ts
+++ b/src/autoload.ts
@@ -4,6 +4,7 @@ import { GLViewer, createViewer } from "./GLViewer";
 import { SurfaceType } from "./ProteinSurface4";
 import { get, specStringToObject } from "./utilities";
 import { CC } from "./colors";
+import { NCBI_PUBCHEM_URL, RCSB_FILES_URL } from "URLs";
 
 export var autoinit = false;
 export var processing_autoinit = false;
@@ -40,12 +41,12 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
 
             type = null;
             if (viewerdiv.dataset.pdb) {
-                datauri.push("https://files.rcsb.org/view/" + viewerdiv.dataset.pdb + ".pdb");
+                datauri.push(RCSB_FILES_URL + viewerdiv.dataset.pdb + ".pdb");
                 datatypes.push("pdb");
             } else if (viewerdiv.dataset.cid) {
                 //this doesn't actually work since pubchem does have CORS enabled
                 datatypes.push("sdf");
-                datauri.push("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/" + viewerdiv.dataset.cid +
+                datauri.push(NCBI_PUBCHEM_URL + viewerdiv.dataset.cid +
                     "/SDF?record_type=3d");
             }
             else if (viewerdiv.dataset.href || viewerdiv.dataset.url) {
@@ -67,7 +68,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
             var divdata = viewerdiv.dataset;
             for (i in divdata) {
                 if ((i.substring(0, 3) === "pdb" && (i !== "pdb"))) {
-                    datauri.push("https://files.rcsb.org/view/" + divdata[i] + ".pdb");
+                    datauri.push(RCSB_FILES_URL + divdata[i] + ".pdb");
                     datatypes.push('pdb');
 
                 } else if (i.substring(0, 4) === "href" && (i !== "href")) {
@@ -75,7 +76,7 @@ export function autoload(viewer?: any, callback?: (arg0: any) => void) {
                     datauri.push(uri);
                     datatypes.push(uri.substring(uri.lastIndexOf('.') + 1));
                 } else if (i.substring(0, 3) === "cid" && (i !== "cid")) {
-                    datauri.push("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/" + divdata[i] + "/SDF?record_type=3d");
+                    datauri.push(NCBI_PUBCHEM_URL + divdata[i] + "/SDF?record_type=3d");
                     datatypes.push('sdf');
                 }
             }

--- a/src/autoload.ts
+++ b/src/autoload.ts
@@ -4,7 +4,7 @@ import { GLViewer, createViewer } from "./GLViewer";
 import { SurfaceType } from "./ProteinSurface4";
 import { get, specStringToObject } from "./utilities";
 import { CC } from "./colors";
-import { NCBI_PUBCHEM_URL, RCSB_FILES_URL } from "URLs";
+import { NCBI_PUBCHEM_URL, RCSB_FILES_URL } from "./URLs";
 
 export var autoinit = false;
 export var processing_autoinit = false;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -403,6 +403,8 @@ export function getbin(uri:string, callback?, request?: RequestMethod, postdata?
     });
  */
 export function download(query, viewer, options, callback?) {
+
+    if(isRequestProcessing) return alert("Request already processing, please wait");
     var type = "";
     var pdbUri = "";
     var mmtfUri = "";
@@ -410,14 +412,10 @@ export function download(query, viewer, options, callback?) {
     var promise = null;
     var m = viewer.addModel();
 
-    if(isRequestProcessing){
-        alert("Request already processing, please wait");
-        return;
-    }
 
     if (query.indexOf(':') < 0) {
         //no type specifier, guess
-        if (query.length == 4) {
+        if (query.length === 4) {
             query = 'pdb:' + query;
         } else if (!isNaN(query)) {
             query = 'cid:' + query;
@@ -460,7 +458,7 @@ export function download(query, viewer, options, callback?) {
                 alert("Wrong PDB ID");
                 return;
             }
-            if (type == 'mmtf') {
+            if (type === 'mmtf') {
                 mmtfUri = options && options.mmtfUri ? options.mmtfUri : RCSB_MMTF_URL;
                 uri = mmtfUri + query.toUpperCase();
             }
@@ -469,7 +467,7 @@ export function download(query, viewer, options, callback?) {
                 uri = pdbUri + query + "." + type;
             }
 
-        } else if (query.substring(0, 4) == 'cid:') {
+        } else if (query.substring(0, 4) === 'cid:') {
             type = "sdf";
             query = query.substring(4);
             if (!query.match(/^[0-9]+$/)) {
@@ -489,7 +487,7 @@ export function download(query, viewer, options, callback?) {
         };
         isRequestProcessing = true;
         promise = new Promise(function (resolve) {
-            if (type == 'mmtf') { //binary data
+            if (type === 'mmtf') { //binary data
                 getbin(uri)
                     .then(function (ret) {
                         handler(ret);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,6 @@
 //a collection of miscellaneous utility functions
 
-import { NCBI_PUBCHEM_URL, RCSB_FILES_URL, RCSB_MMTF_URL } from "URLs";
+import { NCBI_PUBCHEM_URL, RCSB_FILES_URL, RCSB_MMTF_URL } from "./URLs";
 import { builtinGradients, Gradient } from "./Gradient";
 import { VolumeData } from "./VolumeData";
 import { builtinColorSchemes, CC, elementColors, htmlColors, Color } from "./colors";

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -352,7 +352,7 @@ let isRequestProcessing = false;
  * @param uri URL
  * @param callback Function to call with data 
  */
-export function get(uri:string, callback?:(value: unknown) => unknown) {
+export function get(uri:string, callback?) {
     const promise = fetch(uri).then(checkStatus).then((response) => response.text()).finally(()=>isRequestProcessing = false);
     if (callback)
         return promise.then(callback);
@@ -371,7 +371,7 @@ type RequestMethod = "GET"|"POST"|"PUT"|"DELETE"|"HEAD"|"OPTIONS"|"PATCH";
  * @return {Promise}
  */
 
-export function getbin(uri:string, callback?:(value: unknown) => unknown, request?: RequestMethod, postdata?) {
+export function getbin(uri:string, callback?, request?: RequestMethod, postdata?) {
     const promise = fetch(uri, { method: request || "GET", body: postdata })
             .then((response) => checkStatus(response))
             .then((response) => response.arrayBuffer())


### PR DESCRIPTION
# :dizzy: Changelog
:star: In https://3dmol.org/doc/index.html there's a viewer embedded with a download option that can be clicked continuously and an equivalent number of requests will be made, this is not efficient as it'll duplicate multiple requests. A network call on the same action should be allowed only after the previous call fails/succeeds. Throttling has been added so that no duplicate and unnecessary requests are sent.

:star: All the URIs have been moved to a new file `URLs.ts`. If any changes are supposed to be made, it can be updated in one place instead of changing at multiple places which could also be prone to typos. 

:star: Code duplicate in `getBin` function is removed.